### PR TITLE
Add deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.0.2
+
+- Marked as deprecated, please install [dafny-lang.ide-vscode](https://marketplace.visualstudio.com/items?itemName=dafny-lang.ide-vscode) 
+
 ## 2.0.1
 
 - Fixed VSCode compatibility (Promise.any is not a function error)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dafny for Visual Studio Code
 
+> Due to the recent growth of the Dafny extension, we decided to move it to the new "dafny-lang" organization. Please switch to the [new release](https://marketplace.visualstudio.com/items?itemName=dafny-lang.ide-vscode) to ensure that you receive Dafny updates in the future.
+
 This extension adds _Dafny 3_ support to Visual Studio Code. If you require _Dafny 2_ support, consider using the [legacy extension](https://marketplace.visualstudio.com/items?itemName=correctnessLab.dafny-vscode-legacy).
 This VSCode plugin requires the Dafny language server (shipped with the Dafny release since v3.1.0). The plugin will install it automatically upon first use.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dafny-vscode",
   "displayName": "Dafny",
   "description": "Dafny for Visual Studio Code",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "publisher": "correctnessLab",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dafny-vscode",
-  "displayName": "Dafny",
+  "displayName": "Dafny (Deprecated)",
   "description": "Dafny for Visual Studio Code",
   "version": "2.0.2",
   "publisher": "correctnessLab",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dafny-vscode",
   "displayName": "Dafny (Deprecated)",
   "description": "Dafny for Visual Studio Code",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "publisher": "correctnessLab",
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { Disposable, ExtensionContext, OutputChannel, window } from 'vscode';
+import { commands, Disposable, ExtensionContext, OutputChannel, Uri, window } from 'vscode';
 import { ExtensionConstants, LanguageServerConstants } from './constants';
 
 import { DafnyLanguageClient } from './language/dafnyLanguageClient';
@@ -10,11 +10,13 @@ import { timeout } from './tools/timeout';
 
 // Promise.any() is only available since Node.JS 15.
 import * as PromiseAny from 'promise.any';
+import { VSCodeCommands } from './commands';
 
 const DafnyVersionTimeoutMs = 5_000;
 let extensionRuntime: ExtensionRuntime | undefined;
 
 export async function activate(context: ExtensionContext): Promise<void> {
+  showDeprecationNotice();
   if(!await checkAndInformAboutInstallation()) {
     return;
   }
@@ -26,6 +28,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
 export async function deactivate(): Promise<void> {
   await extensionRuntime?.dispose();
+}
+
+async function showDeprecationNotice(): Promise<void> {
+  const selection = await window.showInformationMessage(Messages.Installation.DeprecatedMessage, Messages.Installation.GetLatest);
+  if(selection === Messages.Installation.GetLatest) {
+    await commands.executeCommand(VSCodeCommands.Open, Uri.parse(Messages.Installation.LatestMarketplace));
+  }
 }
 
 class ExtensionRuntime {

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -19,6 +19,12 @@ export namespace Messages {
   export namespace Installation {
     export const Error = 'An error occurred during the installation of Dafny.';
     export const Outdated = 'Your Dafny installation is outdated: ';
+
+    export const DeprecatedMessage = 'Please update Dafny: Due to the recent growth of the Dafny extension, '
+      + 'we decided to move it to the new "dafny-lang" organization. Please switch to the new release to ensure '
+      + ' that you receive Dafny updates in the future.';
+    export const GetLatest = 'Get latest';
+    export const LatestMarketplace = 'https://marketplace.visualstudio.com/items?itemName=dafny-lang.ide-vscode';
   }
 
   export namespace Dotnet {


### PR DESCRIPTION
The Marketplace entry `correctnessLab.dafny-vscode` will be replaced by `dafny-lang.ide-vscode` with https://github.com/dafny-lang/ide-vscode/pull/78. This PR intends to be the last update for the former to encourage users to switch.

Launching the extension will now show this notice:
![image](https://user-images.githubusercontent.com/18049310/141756745-b1514616-e2b7-42e4-92ee-d7c1e8796fad.png)
